### PR TITLE
Alignment with ES-RIS 2023 published edition

### DIFF
--- a/PAXLST.xsd
+++ b/PAXLST.xsd
@@ -1,16 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- ============================================================================================== -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		   xmlns="https://ris.cesni.eu/_assets/ERI-PAXLST/1.3" targetNamespace="https://ris.cesni.eu/_assets/ERI-PAXLST/1.3"
-		   elementFormDefault="qualified" attributeFormDefault="unqualified"
-		   version="1.3">
+<xs:schema	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns="https://ris.cesni.eu/_assets/ERI-PAXLST/1.3"
+	targetNamespace="https://ris.cesni.eu/_assets/ERI-PAXLST/1.3"
+	elementFormDefault="qualified" attributeFormDefault="unqualified"
+	version="1.3">
 	<xs:element name="Person">
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="PersonType">
 					<xs:annotation>
-						<xs:documentation>‘FM’ for crew member
-‘FL’ for passenger
-‘BV’ for stowaway persons</xs:documentation>
+						<xs:documentation>'FM' for crew member
+'FL' for passenger
+'BV' for stowaway persons</xs:documentation>
 					</xs:annotation>
 					<xs:simpleType>
 						<xs:restriction base="xs:string">
@@ -127,7 +129,7 @@ e.g. Chief officer</xs:documentation>
 5 = Deckhand,
 6 = Apprentice,
 7 = Engineer,
-8 = Engine minder,  
+8 = Engine minder,
 9 = Other </xs:documentation>
 						</xs:annotation>
 						<xs:simpleType>
@@ -180,13 +182,11 @@ e.g. Chief officer</xs:documentation>
 				</xs:element>
 				<xs:element name="CrewEffects" minOccurs="0">
 					<xs:annotation>
-						<xs:documentation>Effects ineligible for relief from customs duties and taxes or subject to prohibitions or restrictions
-</xs:documentation>
+						<xs:documentation>Effects ineligible for relief from customs duties and taxes or subject to prohibitions or restrictions</xs:documentation>
 					</xs:annotation>
 					<xs:simpleType>
 						<xs:restriction base="xs:string">
 							<xs:maxLength value="512"/>
-							<xs:minLength value="3"/>
 						</xs:restriction>
 					</xs:simpleType>
 				</xs:element>
@@ -199,12 +199,12 @@ e.g. Chief officer</xs:documentation>
 				<xs:element name="IdentityDocType">
 					<xs:annotation>
 						<xs:documentation>Document type:
-‘39’ Passport
-‘36’ Identity card
-‘SMB’ Seaman's book
-‘40’ Driving licence (national)
-‘41’ Driving licence (international)
-‘483’ Visa</xs:documentation>
+'39' Passport
+'36' Identity card
+'SMB' Seaman's book
+'40' Driving licence (national)
+'41' Driving licence (international)
+'483' Visa</xs:documentation>
 					</xs:annotation>
 					<xs:simpleType>
 						<xs:restriction base="xs:string">
@@ -251,7 +251,7 @@ e.g. Chief officer</xs:documentation>
 	</xs:element>
 	<xs:element name="PAXLST">
 		<xs:annotation>
-			<xs:documentation>ERI PAXLST </xs:documentation>
+			<xs:documentation>ERI PAXLST</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
@@ -394,7 +394,7 @@ e.g. Chief officer</xs:documentation>
 											</xs:element>
 											<xs:element name="IssuingAuthorityENI">
 												<xs:annotation>
-													<xs:documentation>If the nationality of the means of transport is not known the 3 digit code of the competent authority which issued the European Vessel Identification Number should be used.</xs:documentation>
+													<xs:documentation>If the nationality of the means of transport is not known the 3 digit code of the country of the inspection body that issued the last vessel certificate should be used.</xs:documentation>
 												</xs:annotation>
 												<xs:simpleType>
 													<xs:restriction base="xs:string">
@@ -416,7 +416,7 @@ e.g. Chief officer</xs:documentation>
 										</xs:element>
 										<xs:element name="ETD" type="xs:dateTime" minOccurs="0">
 											<xs:annotation>
-												<xs:documentation>Estimated Time of Departure from port of departure. </xs:documentation>
+												<xs:documentation>Estimated Time of Departure from port of departure.</xs:documentation>
 											</xs:annotation>
 										</xs:element>
 										<xs:element name="PortOfDestination" type="LocationType">
@@ -543,7 +543,7 @@ e.g. Chief officer</xs:documentation>
 			</xs:element>
 			<xs:element name="CommonDenominator">
 				<xs:annotation>
-					<xs:documentation>RefNo to group several msgs of same journey corresponds to common access reference </xs:documentation>
+					<xs:documentation>RefNo to group several msgs of same journey corresponds to common access reference</xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="xs:string">

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # paxlst_xsd
 Repository for the PAXLST XSD
+
+Aligned with ES-RIS 2023/1 Annex 13 Appendix 1


### PR DESCRIPTION
Modifications are:
- simple quotes modified from ‘ and ’ to ' (ASCII quotes)
- some meaningless spaces and carriage returns removed
- documentation for IssuingAuthorityENI
- Code "3" removed for CrewEffects

With these changes, this version is 100% consistent with Annex 13, Appoendix 1 of ES-RIS 2023/1